### PR TITLE
Update last tested version to 2024.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,9 +14,7 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "editor.insertSpaces": false,
-    "python.analysis.diagnosticSeverityOverrides": {
-        "reportUndefinedVariable": "none"
-    },
+    "python.analysis.stubPath": "${workspaceFolder}/.vscode/typings",
     "python.analysis.extraPaths": [
         "../nvda/source",
         "../nvda/miscDeps/python"

--- a/.vscode/typings/__builtins__.pyi
+++ b/.vscode/typings/__builtins__.pyi
@@ -1,0 +1,6 @@
+def _(msg: str) -> str:
+	...
+
+
+def pgettext(context: str, message: str) -> str:
+	...

--- a/buildVars.py
+++ b/buildVars.py
@@ -37,7 +37,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3.0", minor version is optional)
 	"addon_minimumNVDAVersion": "0.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion": "2023.1.0",
+	"addon_lastTestedNVDAVersion": "2024.1.0",
 	# Add-on update channel (default is None, denoting stable releases,
 	# and for development releases, use "dev".)
 	# Do not change unless you know what you are doing!


### PR DESCRIPTION
## Link to issue number:
None
### Summary of the issue:
NVDA 2024.1 breaks backwards compatibility.
### Description of how this pull request fixes the issue:
Update last tested version to 2024.1.
### Testing performed:
Tested locally.
### Known issues with pull request:
None.
### Change log entry:
None.